### PR TITLE
Fix vector initialization for node and link value retrieval

### DIFF
--- a/src/impls/link.rs
+++ b/src/impls/link.rs
@@ -123,7 +123,7 @@ impl EPANET {
             Ok(count) => count,
             Err(e) => return Err(e),
         };
-        let mut values: Vec<f64> = Vec::with_capacity(link_count as usize);
+        let mut values: Vec<f64> = vec![0.0; link_count as usize];
         let result =
             unsafe { ffi::EN_getlinkvalues(self.ph, property as i32, values.as_mut_ptr()) };
         if result == 0 {

--- a/src/impls/node.rs
+++ b/src/impls/node.rs
@@ -372,7 +372,7 @@ impl EPANET {
             Ok(count) => count,
             Err(e) => return Err(e),
         };
-        let mut result: Vec<f64> = Vec::with_capacity(node_count as usize);
+        let mut result: Vec<f64> = vec![0.0; node_count as usize];
         unsafe {
             match ffi::EN_getnodevalues(self.ph, node_property as i32, result.as_mut_ptr()) {
                 0 => Ok(result),


### PR DESCRIPTION
## Summary
- Initialize node value buffer with correct length before calling FFI
- Initialize link value buffer with correct length before calling FFI

## Testing
- `cargo test` *(fails: command not found: cargo)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d291d2b8832d89a3df6c28be0360