### PR TITLE
Fix vector initialization for node and link value retrieval

### DIFF
--- a/src/epanet_error.rs
+++ b/src/epanet_error.rs
@@ -60,3 +60,27 @@ impl From<i32> for EPANETError {
         }
     }
 }
+
+/// Convenience helper to convert an EPANET error code into a [`Result`].
+///
+/// The C API uses `0` to indicate success for nearly every function. This helper
+/// centralizes that check and translates non-zero codes into [`EPANETError`].
+pub(crate) fn check_error(code: i32) -> Result<()> {
+    if code == 0 {
+        Ok(())
+    } else {
+        Err(EPANETError::from(code))
+    }
+}
+
+/// Variant of [`check_error`] that attaches additional context to failures.
+pub(crate) fn check_error_with_context(
+    code: i32,
+    context: impl Into<String>,
+) -> Result<()> {
+    if code == 0 {
+        Ok(())
+    } else {
+        Err(EPANETError::from(code).with_context(context))
+    }
+}

--- a/src/impls/link.rs
+++ b/src/impls/link.rs
@@ -12,57 +12,35 @@ use std::ffi::{c_char, CString};
 /// ## Link APIs
 impl EPANET {
     pub fn delete_link(&self, index: i32, action_code_type: ActionCodeType) -> Result<()> {
-        let result = unsafe { ffi::EN_deletelink(self.ph, index, action_code_type as i32) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_deletelink(self.ph, index, action_code_type as i32) })
     }
 
     pub fn get_link_index(&self, id: &str) -> Result<i32> {
         let c_id = CString::new(id).unwrap();
         let mut out_index = 0;
-        let result = unsafe { ffi::EN_getlinkindex(self.ph, c_id.as_ptr(), &mut out_index) };
-        if result == 0 {
-            Ok(out_index)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getlinkindex(self.ph, c_id.as_ptr(), &mut out_index) })?;
+        Ok(out_index)
     }
 
     pub fn get_link_id(&self, index: i32) -> Result<String> {
         let mut out_id: Vec<c_char> = vec![0; MAX_ID_SIZE as usize + 1usize];
-        let result = unsafe { ffi::EN_getlinkid(self.ph, index, out_id.as_mut_ptr()) };
-        if result == 0 {
-            let id = unsafe { std::ffi::CStr::from_ptr(out_id.as_ptr()) }
-                .to_string_lossy()
-                .trim_end()
-                .to_string();
-            Ok(id)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getlinkid(self.ph, index, out_id.as_mut_ptr()) })?;
+        let id = unsafe { std::ffi::CStr::from_ptr(out_id.as_ptr()) }
+            .to_string_lossy()
+            .trim_end()
+            .to_string();
+        Ok(id)
     }
 
     pub fn set_link_id(&self, index: i32, id: &str) -> Result<()> {
         let c_id = CString::new(id).unwrap();
-        let result = unsafe { ffi::EN_setlinkid(self.ph, index, c_id.as_ptr()) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setlinkid(self.ph, index, c_id.as_ptr()) })
     }
 
     pub fn get_link_type(&self, index: i32) -> Result<LinkType> {
         let mut out_type = 0;
-        let result = unsafe { ffi::EN_getlinktype(self.ph, index, &mut out_type) };
-        if result == 0 {
-            Ok(LinkType::from_i32(out_type).unwrap())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getlinktype(self.ph, index, &mut out_type) })?;
+        Ok(LinkType::from_i32(out_type).unwrap())
     }
 
     pub fn set_link_type(
@@ -80,42 +58,28 @@ impl EPANET {
                 action_code as i32,
             )
         };
-        if result == 0 {
-            Ok(in_out_index)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(result)?;
+        Ok(in_out_index)
     }
 
     pub fn get_link_nodes(&self, index: i32) -> Result<(i32, i32)> {
         let (mut out_node1, mut out_node2) = (0, 0);
-        let result =
-            unsafe { ffi::EN_getlinknodes(self.ph, index, &mut out_node1, &mut out_node2) };
-        if result == 0 {
-            Ok((out_node1, out_node2))
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe {
+            ffi::EN_getlinknodes(self.ph, index, &mut out_node1, &mut out_node2)
+        })?;
+        Ok((out_node1, out_node2))
     }
 
     pub fn set_link_nodes(&self, index: i32, node1: i32, node2: i32) -> Result<()> {
-        let result = unsafe { ffi::EN_setlinknodes(self.ph, index, node1, node2) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setlinknodes(self.ph, index, node1, node2) })
     }
 
     pub fn get_link_value(&self, index: i32, property: LinkProperty) -> Result<f64> {
         let mut out_value = 0.0;
-        let result =
-            unsafe { ffi::EN_getlinkvalue(self.ph, index, property as i32, &mut out_value) };
-        if result == 0 {
-            Ok(out_value)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe {
+            ffi::EN_getlinkvalue(self.ph, index, property as i32, &mut out_value)
+        })?;
+        Ok(out_value)
     }
 
     pub fn get_link_values(&self, property: LinkProperty) -> Result<Vec<f64>> {
@@ -123,7 +87,7 @@ impl EPANET {
             Ok(count) => count,
             Err(e) => return Err(e),
         };
-        let mut values: Vec<f64> = Vec::with_capacity(link_count as usize);
+        let mut values: Vec<f64> = vec![0.0; link_count as usize];
         let result =
             unsafe { ffi::EN_getlinkvalues(self.ph, property as i32, values.as_mut_ptr()) };
         if result == 0 {
@@ -161,66 +125,41 @@ impl EPANET {
 
     pub fn get_pump_type(&self, index: i32) -> Result<PumpType> {
         let mut out_type = 0;
-        let result = unsafe { ffi::EN_getpumptype(self.ph, index, &mut out_type) };
-        if result == 0 {
-            Ok(PumpType::from_i32(out_type).unwrap())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getpumptype(self.ph, index, &mut out_type) })?;
+        Ok(PumpType::from_i32(out_type).unwrap())
     }
 
     pub fn get_head_curve_index(&self, link_index: i32) -> Result<i32> {
         let mut out_index = 0;
-        let result = unsafe { ffi::EN_getheadcurveindex(self.ph, link_index, &mut out_index) };
-        if result == 0 {
-            Ok(out_index)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getheadcurveindex(self.ph, link_index, &mut out_index) })?;
+        Ok(out_index)
     }
 
     pub fn set_head_curve_index(&self, link_index: i32, curve_index: i32) -> Result<()> {
-        let result = unsafe { ffi::EN_setheadcurveindex(self.ph, link_index, curve_index) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setheadcurveindex(self.ph, link_index, curve_index) })
     }
 
     pub fn get_vertex_count(&self, link_index: i32) -> Result<i32> {
         let mut out_count = 0;
-        let result = unsafe { ffi::EN_getvertexcount(self.ph, link_index, &mut out_count) };
-        if result == 0 {
-            Ok(out_count)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getvertexcount(self.ph, link_index, &mut out_count) })?;
+        Ok(out_count)
     }
 
     pub fn get_vertex(&self, link_index: i32, vertex_index: i32) -> Result<(f64, f64)> {
         let (mut out_x, mut out_y) = (0.0, 0.0);
-        let result =
-            unsafe { ffi::EN_getvertex(self.ph, link_index, vertex_index, &mut out_x, &mut out_y) };
-        if result == 0 {
-            Ok((out_x, out_y))
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe {
+            ffi::EN_getvertex(self.ph, link_index, vertex_index, &mut out_x, &mut out_y)
+        })?;
+        Ok((out_x, out_y))
     }
 
     pub fn set_vertex(&self, link_index: i32, vertex_index: i32, x: f64, y: f64) -> Result<()> {
-        let result = unsafe { ffi::EN_setvertex(self.ph, link_index, vertex_index, x, y) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setvertex(self.ph, link_index, vertex_index, x, y) })
     }
 
     pub fn set_vertices(&self, link_index: i32, vertices: Vec<(f64, f64)>) -> Result<()> {
         let (mut xs, mut ys): (Vec<f64>, Vec<f64>) = vertices.iter().cloned().unzip();
-        let result = unsafe {
+        check_error(unsafe {
             ffi::EN_setvertices(
                 self.ph,
                 link_index,
@@ -228,11 +167,6 @@ impl EPANET {
                 ys.as_mut_ptr(),
                 vertices.len() as i32,
             )
-        };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        })
     }
 }

--- a/src/impls/node.rs
+++ b/src/impls/node.rs
@@ -57,20 +57,19 @@ impl EPANET {
     pub fn add_node(&self, id: &str, node_type: NodeType) -> Result<i32> {
         let _id = CString::new(id).unwrap();
         let mut out_index = MaybeUninit::uninit();
-        unsafe {
-            match ffi::EN_addnode(
+        let code = unsafe {
+            ffi::EN_addnode(
                 self.ph,
                 _id.as_ptr(),
                 node_type as i32,
                 out_index.as_mut_ptr(),
-            ) {
-                0 => Ok(out_index.assume_init()),
-                x => Err(EPANETError::from(x).with_context(format!(
-                    "Failed to add node of type {:?} with id {}",
-                    node_type, id
-                ))),
-            }
-        }
+            )
+        };
+        check_error_with_context(
+            code,
+            format!("Failed to add node of type {:?} with id {}", node_type, id),
+        )?;
+        Ok(unsafe { out_index.assume_init() })
     }
 
     /// Deletes a node from the EPANET model.
@@ -113,15 +112,14 @@ impl EPANET {
     /// - `EN_deletenode` (EPANET C API)
     /// - [`ActionCodeType`] for possible adjustment actions when deleting a node.
     pub fn delete_node(&self, id: i32, action_code: ActionCodeType) -> Result<()> {
-        unsafe {
-            match ffi::EN_deletenode(self.ph, id, action_code as i32) {
-                0 => Ok(()),
-                x => Err(EPANETError::from(x).with_context(format!(
-                    "Failed to delete node with id {} with action code {:?}",
-                    id, action_code
-                ))),
-            }
-        }
+        let code = unsafe { ffi::EN_deletenode(self.ph, id, action_code as i32) };
+        check_error_with_context(
+            code,
+            format!(
+                "Failed to delete node with id {} with action code {:?}",
+                id, action_code
+            ),
+        )
     }
 
     /// Retrieves the index of a node in the EPANET model given its ID.
@@ -161,13 +159,12 @@ impl EPANET {
     pub fn get_node_index(&self, id: &str) -> Result<i32> {
         let _id = CString::new(id).unwrap();
         let mut out_index = MaybeUninit::uninit();
-        unsafe {
-            match ffi::EN_getnodeindex(self.ph, _id.as_ptr(), out_index.as_mut_ptr()) {
-                0 => Ok(out_index.assume_init()),
-                x => Err(EPANETError::from(x)
-                    .with_context(format!("Failed to get index for node with id {}", id))),
-            }
-        }
+        let code = unsafe { ffi::EN_getnodeindex(self.ph, _id.as_ptr(), out_index.as_mut_ptr()) };
+        check_error_with_context(
+            code,
+            format!("Failed to get index for node with id {}", id),
+        )?;
+        Ok(unsafe { out_index.assume_init() })
     }
 
     /// Retrieves the ID of a specific node in the EPANET model.
@@ -210,16 +207,12 @@ impl EPANET {
     /// - [`MAX_MSG_SIZE`] for the size limit used for node IDs.
     pub fn get_node_id(&self, index: i32) -> Result<String> {
         let mut out_id: Vec<c_char> = vec![0; MAX_MSG_SIZE as usize + 1usize];
-        unsafe {
-            match ffi::EN_getnodeid(self.ph, index, out_id.as_mut_ptr()) {
-                0 => Ok(CStr::from_ptr(out_id.as_ptr())
-                    .to_str()
-                    .unwrap()
-                    .to_string()),
-                x => Err(EPANETError::from(x)
-                    .with_context(format!("Failed to get node id for node at index {}", index))),
-            }
-        }
+        let code = unsafe { ffi::EN_getnodeid(self.ph, index, out_id.as_mut_ptr()) };
+        check_error_with_context(
+            code,
+            format!("Failed to get node id for node at index {}", index),
+        )?;
+        Ok(unsafe { CStr::from_ptr(out_id.as_ptr()) }.to_string_lossy().to_string())
     }
 
     /// Changes the ID of a specific node in the EPANET model.
@@ -262,15 +255,14 @@ impl EPANET {
     /// - EN_setnodeid (EPANET C API)
     pub fn set_node_id(&self, index: i32, node_id: &str) -> Result<()> {
         let _id = CString::new(node_id).unwrap();
-        unsafe {
-            match ffi::EN_setnodeid(self.ph, index, _id.as_ptr()) {
-                0 => Ok(()),
-                x => Err(EPANETError::from(x).with_context(format!(
-                    "Failed to set the id of {} for node at index {}",
-                    node_id, index
-                ))),
-            }
-        }
+        let code = unsafe { ffi::EN_setnodeid(self.ph, index, _id.as_ptr()) };
+        check_error_with_context(
+            code,
+            format!(
+                "Failed to set the id of {} for node at index {}",
+                node_id, index
+            ),
+        )
     }
 
     /// Retrieves the type of a specific node in the EPANET model.
@@ -310,18 +302,13 @@ impl EPANET {
     /// - [`NodeType`] for the list of possible node types returned by this function.
     pub fn get_node_type(&self, index: i32) -> Result<NodeType> {
         let mut node_type: MaybeUninit<c_int> = MaybeUninit::uninit();
-        unsafe {
-            match ffi::EN_getnodetype(self.ph, index, node_type.as_mut_ptr()) {
-                0 => {
-                    let init_node_type = node_type.assume_init();
-                    Ok(NodeType::from_i32(init_node_type).unwrap())
-                }
-                x => Err(EPANETError::from(x).with_context(format!(
-                    "Failed to get node type for node at index {}",
-                    index
-                ))),
-            }
-        }
+        let code = unsafe { ffi::EN_getnodetype(self.ph, index, node_type.as_mut_ptr()) };
+        check_error_with_context(
+            code,
+            format!("Failed to get node type for node at index {}", index),
+        )?;
+        let init_node_type = unsafe { node_type.assume_init() };
+        Ok(NodeType::from_i32(init_node_type).unwrap())
     }
 
     /// Retrieves the values of a specific property for all nodes in the EPANET model.
@@ -368,18 +355,13 @@ impl EPANET {
     /// - [`NodeProperty`] for the list of available properties that can be retrieved.
     /// - [`get_count`] for determining the total number of nodes.
     pub fn get_node_values(&self, node_property: NodeProperty) -> Result<Vec<f64>> {
-        let node_count = match self.get_count(NodeCount) {
-            Ok(count) => count,
-            Err(e) => return Err(e),
-        };
-        let mut result: Vec<f64> = Vec::with_capacity(node_count as usize);
-        unsafe {
-            match ffi::EN_getnodevalues(self.ph, node_property as i32, result.as_mut_ptr()) {
-                0 => Ok(result),
-                x => Err(EPANETError::from(x)
-                    .with_context(format!("Failed to get {:?} for all nodes", node_property))),
-            }
-        }
+        let node_count = self.get_count(NodeCount)?;
+        let mut result: Vec<f64> = vec![0.0; node_count as usize];
+        check_error_with_context(
+            unsafe { ffi::EN_getnodevalues(self.ph, node_property as i32, result.as_mut_ptr()) },
+            format!("Failed to get {:?} for all nodes", node_property),
+        )?;
+        Ok(result)
     }
 
     /// Retrieves the value of a specific property for a node in the EPANET model.
@@ -416,15 +398,14 @@ impl EPANET {
     /// - EN_getnodevalue (EPANET C API)
     pub fn get_node_value(&self, index: i32, node_property: NodeProperty) -> Result<f64> {
         let mut value: MaybeUninit<f64> = MaybeUninit::uninit();
-        unsafe {
-            match ffi::EN_getnodevalue(self.ph, index, node_property as i32, value.as_mut_ptr()) {
-                0 => Ok(value.assume_init()),
-                x => Err(EPANETError::from(x).with_context(format!(
-                    "Failed to get {:?} for node at index {}",
-                    node_property, index
-                ))),
-            }
-        }
+        check_error_with_context(
+            unsafe { ffi::EN_getnodevalue(self.ph, index, node_property as i32, value.as_mut_ptr()) },
+            format!(
+                "Failed to get {:?} for node at index {}",
+                node_property, index
+            ),
+        )?;
+        Ok(unsafe { value.assume_init() })
     }
 
     /// Sets the value of a specific property for a node in the EPANET model.
@@ -469,14 +450,11 @@ impl EPANET {
     ) -> Result<()> {
         // Convert `usize` to `i32` explicitly for FFI
         let index = index as i32;
-
-        match unsafe { ffi::EN_setnodevalue(self.ph, index, node_property as i32, value) } {
-            0 => Ok(()),
-            x => Err(EPANETError::from(x).with_context(format!(
-                "Failed to set {:?} for node at index {}",
-                node_property, index
-            ))),
-        }
+        let code = unsafe { ffi::EN_setnodevalue(self.ph, index, node_property as i32, value) };
+        check_error_with_context(
+            code,
+            format!("Failed to set {:?} for node at index {}", node_property, index),
+        )
     }
 }
 

--- a/src/impls/options.rs
+++ b/src/impls/options.rs
@@ -13,62 +13,35 @@ use std::ffi::{c_char, CString};
 
 /// ## Analysis Options APIs
 impl EPANET {
-    pub fn get_option(&self, option: Option) -> Result<f64> {
-        let mut value: f64 = 0.0;
-        let result = unsafe { ffi::EN_getoption(self.ph, option as i32, &mut value) };
-        if result == 0 {
+        pub fn get_option(&self, option: Option) -> Result<f64> {
+            let mut value: f64 = 0.0;
+            check_error(unsafe { ffi::EN_getoption(self.ph, option as i32, &mut value) })?;
             Ok(value)
-        } else {
-            Err(EPANETError::from(result))
         }
-    }
 
-    pub fn set_option(&self, option: Option, value: f64) -> Result<()> {
-        let result = unsafe { ffi::EN_setoption(self.ph, option as i32, value) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
+        pub fn set_option(&self, option: Option, value: f64) -> Result<()> {
+            check_error(unsafe { ffi::EN_setoption(self.ph, option as i32, value) })
         }
-    }
 
-    pub fn get_flow_units(&self) -> Result<FlowUnits> {
-        let mut flow_units = 0; // Default value
-        let result = unsafe { ffi::EN_getflowunits(self.ph, &mut flow_units) };
-        if result == 0 {
+        pub fn get_flow_units(&self) -> Result<FlowUnits> {
+            let mut flow_units = 0; // Default value
+            check_error(unsafe { ffi::EN_getflowunits(self.ph, &mut flow_units) })?;
             Ok(FlowUnits::from_i32(flow_units).unwrap())
-        } else {
-            Err(EPANETError::from(result))
         }
-    }
 
-    pub fn set_flow_units(&self, flow_units: FlowUnits) -> Result<()> {
-        let result = unsafe { ffi::EN_setflowunits(self.ph, flow_units as i32) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
+        pub fn set_flow_units(&self, flow_units: FlowUnits) -> Result<()> {
+            check_error(unsafe { ffi::EN_setflowunits(self.ph, flow_units as i32) })
         }
-    }
 
     pub fn get_time_parameter(&self, parameter: TimeParameter) -> Result<i64> {
         let mut value: i64 = 0;
-        let result = unsafe { ffi::EN_gettimeparam(self.ph, parameter as i32, &mut value) };
-        if result == 0 {
+            check_error(unsafe { ffi::EN_gettimeparam(self.ph, parameter as i32, &mut value) })?;
             Ok(value)
-        } else {
-            Err(EPANETError::from(result))
         }
-    }
 
     pub fn set_time_parameter(&self, parameter: TimeParameter, value: i64) -> Result<()> {
-        let result = unsafe { ffi::EN_settimeparam(self.ph, parameter as i32, value) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
+            check_error(unsafe { ffi::EN_settimeparam(self.ph, parameter as i32, value) })
         }
-    }
 
     pub fn get_quality_info(&self) -> Result<QualityAnalysisInfo> {
         let mut quality_type: i32 = 0;
@@ -86,9 +59,7 @@ impl EPANET {
             )
         };
 
-        if result != 0 {
-            return Err(EPANETError::from(result));
-        }
+        check_error(result)?;
 
         let quality_type =
             QualityType::from_i32(quality_type).ok_or_else(|| EPANETError::from(result))?;
@@ -121,11 +92,8 @@ impl EPANET {
 
         let result =
             unsafe { ffi::EN_getqualtype(self.ph, &mut quality_type, &mut trace_node_index) };
-        if result == 0 {
-            Ok(QualityType::from_i32(quality_type).unwrap())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(result)?;
+        Ok(QualityType::from_i32(quality_type).unwrap())
     }
 
     pub fn set_quality_type(
@@ -149,11 +117,7 @@ impl EPANET {
             )
         };
 
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(result)
     }
 }
 

--- a/src/impls/pattern.rs
+++ b/src/impls/pattern.rs
@@ -11,107 +11,60 @@ use std::path::Path;
 impl EPANET {
     pub fn add_pattern(&self, id: &str) -> Result<()> {
         let c_id = std::ffi::CString::new(id).unwrap();
-        let result = unsafe { ffi::EN_addpattern(self.ph, c_id.as_ptr()) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_addpattern(self.ph, c_id.as_ptr()) })
     }
 
     pub fn delete_pattern(&self, index: i32) -> Result<()> {
-        let result = unsafe { ffi::EN_deletepattern(self.ph, index) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_deletepattern(self.ph, index) })
     }
 
     pub fn get_pattern_id(&self, index: i32) -> Result<String> {
         let mut out_id: Vec<std::ffi::c_char> = vec![0; MAX_ID_SIZE as usize + 1];
-        let result = unsafe { ffi::EN_getpatternid(self.ph, index, out_id.as_mut_ptr()) };
-        if result == 0 {
-            let id = unsafe { std::ffi::CStr::from_ptr(out_id.as_ptr()) }
-                .to_str()
-                .unwrap_or("")
-                .trim_end()
-                .to_string();
-            Ok(id)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getpatternid(self.ph, index, out_id.as_mut_ptr()) })?;
+        let id = unsafe { std::ffi::CStr::from_ptr(out_id.as_ptr()) }
+            .to_str()
+            .unwrap_or("")
+            .trim_end()
+            .to_string();
+        Ok(id)
     }
 
     pub fn set_pattern_id(&self, index: i32, id: &str) -> Result<()> {
         let c_id = std::ffi::CString::new(id).unwrap();
-        let result = unsafe { ffi::EN_setpatternid(self.ph, index, c_id.as_ptr()) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setpatternid(self.ph, index, c_id.as_ptr()) })
     }
 
     pub fn get_pattern_length(&self, index: i32) -> Result<i32> {
         let mut out_length = 0;
-        let result = unsafe { ffi::EN_getpatternlen(self.ph, index, &mut out_length) };
-        if result == 0 {
-            Ok(out_length)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getpatternlen(self.ph, index, &mut out_length) })?;
+        Ok(out_length)
     }
 
     pub fn get_pattern_value(&self, index: i32, period: i32) -> Result<f64> {
         let mut out_value = 0.0;
-        let result = unsafe { ffi::EN_getpatternvalue(self.ph, index, period, &mut out_value) };
-        if result == 0 {
-            Ok(out_value)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getpatternvalue(self.ph, index, period, &mut out_value) })?;
+        Ok(out_value)
     }
 
     pub fn set_pattern_value(&self, index: i32, period: i32, value: f64) -> Result<()> {
-        let result = unsafe { ffi::EN_setpatternvalue(self.ph, index, period, value) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setpatternvalue(self.ph, index, period, value) })
     }
 
     pub fn get_average_pattern_value(&self, index: i32) -> Result<f64> {
         let mut out_value = 0.0;
-        let result = unsafe { ffi::EN_getaveragepatternvalue(self.ph, index, &mut out_value) };
-        if result == 0 {
-            Ok(out_value)
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_getaveragepatternvalue(self.ph, index, &mut out_value) })?;
+        Ok(out_value)
     }
 
     pub fn set_pattern(&self, index: i32, values: &[f64]) -> Result<()> {
         let c_values = values.as_ptr() as *mut f64;
-        let result = unsafe { ffi::EN_setpattern(self.ph, index, c_values, values.len() as i32) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_setpattern(self.ph, index, c_values, values.len() as i32) })
     }
 
     pub fn load_pattern_file(&self, file_name: &Path, id: &str) -> Result<()> {
         let c_file_name = std::ffi::CString::new(file_name.to_str().unwrap()).unwrap();
         let c_id = std::ffi::CString::new(id).unwrap();
 
-        let result =
-            unsafe { ffi::EN_loadpatternfile(self.ph, c_file_name.as_ptr(), c_id.as_ptr()) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(EPANETError::from(result))
-        }
+        check_error(unsafe { ffi::EN_loadpatternfile(self.ph, c_file_name.as_ptr(), c_id.as_ptr()) })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,8 @@ impl EPANET {
     fn create_project_handle() -> Result<ffi::EN_Project> {
         let mut ph: ffi::EN_Project = std::ptr::null_mut();
         let result = unsafe { ffi::EN_createproject(&mut ph) };
-        if result != 0 {
-            Err(EPANETError::from(result))
-        } else {
-            Ok(ph)
-        }
+        check_error(result)?;
+        Ok(ph)
     }
     /// Creates a new EPANET instance by reading an input file.
     ///
@@ -64,9 +61,9 @@ impl EPANET {
                 head_loss_type as i32,
             )
         };
-        if result != 0 {
+        if let Err(e) = check_error(result) {
             unsafe { ffi::EN_deleteproject(ph) }; // Clean up on failure
-            return Err(EPANETError::from(result));
+            return Err(e);
         }
 
         // Step 4: Return the EPANET instance
@@ -84,9 +81,9 @@ impl EPANET {
 
         // Step 3: Open the project
         let result = unsafe { ffi::EN_open(ph, inp.as_ptr(), rpt.as_ptr(), out.as_ptr()) };
-        if result != 0 {
+        if let Err(e) = check_error(result) {
             unsafe { ffi::EN_deleteproject(ph) }; // Clean up on failure
-            return Err(EPANETError::from(result));
+            return Err(e);
         }
 
         // Step 4: Return the EPANET instance
@@ -108,9 +105,9 @@ impl EPANET {
 
         // Step 3: Open the project
         let result = unsafe { ffi::EN_open(ph, inp.as_ptr(), rpt.as_ptr(), out.as_ptr()) };
-        if result != 0 {
+        if let Err(e) = check_error(result) {
             unsafe { ffi::EN_deleteproject(ph) }; // Clean up on failure
-            return Err(EPANETError::from(result));
+            return Err(e);
         }
 
         // Step 4: Return the EPANET instance


### PR DESCRIPTION
## Summary
- Initialize node and link value buffers with correct lengths before calling FFI
- Centralize FFI error handling with `check_error` helpers and refactor callers

## Testing
- `cargo test` *(fails: The source directory "/workspace/rusty-epanet/EPANET" does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d291d2b8832d89a3df6c28be0360